### PR TITLE
Don't loose selection when adding and removing rich style

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -152,7 +152,9 @@ export const Editable = (props: EditableProps) => {
       hasDomSelection &&
       newDomRange &&
       (isRangeEqual(domSelection.getRangeAt(0), newDomRange) ||
-        (selection && !Range.isCollapsed(selection)))
+        (selection &&
+          !Range.isCollapsed(selection) &&
+          !domSelection.getRangeAt(0).collapsed))
     ) {
       return
     }


### PR DESCRIPTION
Fix this:

![rich-text-bug](https://user-images.githubusercontent.com/11168195/80365730-99244c00-8877-11ea-8411-e7346eac016e.gif)
